### PR TITLE
Extracted interfaces from UndoService and ChangeFactory for IoC container registration

### DIFF
--- a/src/MonitoredUndo/ChangeFactory.cs
+++ b/src/MonitoredUndo/ChangeFactory.cs
@@ -11,10 +11,10 @@ using MonitoredUndo.Changes;
 
 namespace MonitoredUndo
 {
-
-    public class ChangeFactory
+    /// <inheritdoc cref="IChangeFactory"/>
+    public class ChangeFactory : IChangeFactory
     {
-
+        /// <inheritdoc cref="IChangeFactory.ThrowExceptionOnCollectionResets"/>
         public bool ThrowExceptionOnCollectionResets
         {
             get { return _ThrowExceptionOnCollectionResets; }
@@ -23,14 +23,7 @@ namespace MonitoredUndo
         private bool _ThrowExceptionOnCollectionResets = true;
 
 
-        /// <summary>
-        /// Construct a Change instance with actions for undo / redo.
-        /// </summary>
-        /// <param name="instance">The instance that changed.</param>
-        /// <param name="propertyName">The property name that changed. (Case sensitive, used by reflection.)</param>
-        /// <param name="oldValue">The old value of the property.</param>
-        /// <param name="newValue">The new value of the property.</param>
-        /// <returns>A Change that can be added to the UndoRoot's undo stack.</returns>
+        /// <inheritdoc cref="IChangeFactory.GetChange(object, string, object, object)"/>
         public virtual Change GetChange(object instance, string propertyName, object oldValue, object newValue)
         {
             var undoMetadata = instance as IUndoMetadata;
@@ -45,26 +38,13 @@ namespace MonitoredUndo
             return change;
         }
 
-        /// <summary>
-        /// Construct a Change instance with actions for undo / redo.
-        /// </summary>
-        /// <param name="instance">The instance that changed.</param>
-        /// <param name="propertyName">The property name that changed. (Case sensitive, used by reflection.)</param>
-        /// <param name="oldValue">The old value of the property.</param>
-        /// <param name="newValue">The new value of the property.</param>
+        /// <inheritdoc cref="IChangeFactory.OnChanging(object, string, object, object)"/>
         public virtual void OnChanging(object instance, string propertyName, object oldValue, object newValue)
         {
             OnChanging(instance, propertyName, oldValue, newValue, propertyName);
         }
 
-        /// <summary>
-        /// Construct a Change instance with actions for undo / redo.
-        /// </summary>
-        /// <param name="instance">The instance that changed.</param>
-        /// <param name="propertyName">The property name that changed. (Case sensitive, used by reflection.)</param>
-        /// <param name="oldValue">The old value of the property.</param>
-        /// <param name="newValue">The new value of the property.</param>
-        /// <param name="descriptionOfChange">A description of this change.</param>
+        /// <inheritdoc cref="IChangeFactory.OnChanging(object, string, object, object, string)"/>
         public virtual void OnChanging(object instance, string propertyName, object oldValue, object newValue, string descriptionOfChange)
         {
             var supportsUndo = instance as ISupportsUndo;
@@ -80,14 +60,7 @@ namespace MonitoredUndo
             UndoService.Current[root].AddChange(change, descriptionOfChange);
         }
 
-        /// <summary>
-        /// Construct a Change instance with actions for undo / redo.
-        /// </summary>
-        /// <param name="instance">The instance that changed.</param>
-        /// <param name="propertyName">The property name that exposes the collection that changed. (Case sensitive, used by reflection.)</param>
-        /// <param name="collection">The collection that had an item added / removed.</param>
-        /// <param name="e">The NotifyCollectionChangedEventArgs event args parameter, with info about the collection change.</param>
-        /// <returns>A Change that can be added to the UndoRoot's undo stack.</returns>
+        /// <inheritdoc cref="IChangeFactory.GetCollectionChange(object, string, object, NotifyCollectionChangedEventArgs)"/>
         public virtual IList<Change> GetCollectionChange(object instance, string propertyName, object collection, NotifyCollectionChangedEventArgs e)
         {
             var undoMetadata = instance as IUndoMetadata;
@@ -104,7 +77,7 @@ namespace MonitoredUndo
                 case NotifyCollectionChangedAction.Add:
                     foreach (var item in e.NewItems)
                     {
-                        Change change = null; 
+                        Change change = null;
                         if (collection as IList != null)
                         {
                             change = new CollectionAddChange(instance, propertyName, (IList)collection,
@@ -116,7 +89,7 @@ namespace MonitoredUndo
                             var keyProperty = item.GetType().GetProperty("Key");
                             var valueProperty = item.GetType().GetProperty("Value");
                             change = new DictionaryAddChange(instance, propertyName, (IDictionary)collection,
-                                                                 keyProperty.GetValue(item, null), valueProperty.GetValue(item, null));                            
+                                                                 keyProperty.GetValue(item, null), valueProperty.GetValue(item, null));
                         }
                         ret.Add(change);
                     }
@@ -146,7 +119,7 @@ namespace MonitoredUndo
                     break;
 
                 case NotifyCollectionChangedAction.Move:
-                    var moveChange = new CollectionMoveChange(instance, propertyName, (IList) collection,
+                    var moveChange = new CollectionMoveChange(instance, propertyName, (IList)collection,
                                                               e.NewStartingIndex,
                                                               e.OldStartingIndex);
                     ret.Add(moveChange);
@@ -156,7 +129,7 @@ namespace MonitoredUndo
                     for (int i = 0; i < e.OldItems.Count; i++)
                     {
                         Change change = null;
-                        
+
                         if (collection as IList != null)
                         {
                             change = new CollectionReplaceChange(instance, propertyName, (IList)collection,
@@ -188,26 +161,13 @@ namespace MonitoredUndo
             return ret;
         }
 
-        /// <summary>
-        /// Construct a Change instance with actions for undo / redo.
-        /// </summary>
-        /// <param name="instance">The instance that changed.</param>
-        /// <param name="propertyName">The property name that exposes the collection that changed. (Case sensitive, used by reflection.)</param>
-        /// <param name="collection">The collection that had an item added / removed.</param>
-        /// <param name="e">The NotifyCollectionChangedEventArgs event args parameter, with info about the collection change.</param>
+        /// <inheritdoc cref="IChangeFactory.OnCollectionChanged(object, string, object, NotifyCollectionChangedEventArgs)"/>
         public virtual void OnCollectionChanged(object instance, string propertyName, object collection, NotifyCollectionChangedEventArgs e)
         {
             OnCollectionChanged(instance, propertyName, collection, e, propertyName);
         }
 
-        /// <summary>
-        /// Construct a Change instance with actions for undo / redo.
-        /// </summary>
-        /// <param name="instance">The instance that changed.</param>
-        /// <param name="propertyName">The property name that exposes the collection that changed. (Case sensitive, used by reflection.)</param>
-        /// <param name="collection">The collection that had an item added / removed.</param>
-        /// <param name="e">The NotifyCollectionChangedEventArgs event args parameter, with info about the collection change.</param>
-        /// <param name="descriptionOfChange">A description of the change.</param>
+        /// <inheritdoc cref="IChangeFactory.OnCollectionChanged(object, string, object, NotifyCollectionChangedEventArgs, string)"/>
         public virtual void OnCollectionChanged(object instance, string propertyName, object collection, NotifyCollectionChangedEventArgs e, string descriptionOfChange)
         {
             var supportsUndo = instance as ISupportsUndo;

--- a/src/MonitoredUndo/IChangeFactory.cs
+++ b/src/MonitoredUndo/IChangeFactory.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+
+namespace MonitoredUndo
+{
+    /// <summary>
+    /// A factory for creating <see cref="Change"/> instances.
+    /// </summary>
+    public interface IChangeFactory
+    {
+        /// <summary>
+        /// Whether to throw an exception when attempting to create a collection change for a collection that has been reset.
+        /// </summary>
+        bool ThrowExceptionOnCollectionResets { get; set; }
+
+        /// <summary>
+        /// Construct a Change instance with actions for undo / redo.
+        /// </summary>
+        /// <param name="instance">The instance that changed.</param>
+        /// <param name="propertyName">The property name that changed. (Case sensitive, used by reflection.)</param>
+        /// <param name="oldValue">The old value of the property.</param>
+        /// <param name="newValue">The new value of the property.</param>
+        /// <returns>A Change that can be added to the UndoRoot's undo stack.</returns>
+        Change GetChange(object instance, string propertyName, object oldValue, object newValue);
+
+        /// <summary>
+        /// Construct a Change instance with actions for undo / redo.
+        /// </summary>
+        /// <param name="instance">The instance that changed.</param>
+        /// <param name="propertyName">The property name that exposes the collection that changed. (Case sensitive, used by reflection.)</param>
+        /// <param name="collection">The collection that had an item added / removed.</param>
+        /// <param name="e">The NotifyCollectionChangedEventArgs event args parameter, with info about the collection change.</param>
+        /// <returns>A Change that can be added to the UndoRoot's undo stack.</returns>
+        IList<Change> GetCollectionChange(object instance, string propertyName, object collection, NotifyCollectionChangedEventArgs e);
+
+        /// <summary>
+        /// Construct a Change instance with actions for undo / redo.
+        /// </summary>
+        /// <param name="instance">The instance that changed.</param>
+        /// <param name="propertyName">The property name that changed. (Case sensitive, used by reflection.)</param>
+        /// <param name="oldValue">The old value of the property.</param>
+        /// <param name="newValue">The new value of the property.</param>
+        void OnChanging(object instance, string propertyName, object oldValue, object newValue);
+
+        /// <summary>
+        /// Construct a Change instance with actions for undo / redo.
+        /// </summary>
+        /// <param name="instance">The instance that changed.</param>
+        /// <param name="propertyName">The property name that changed. (Case sensitive, used by reflection.)</param>
+        /// <param name="oldValue">The old value of the property.</param>
+        /// <param name="newValue">The new value of the property.</param>
+        /// <param name="descriptionOfChange">A description of this change.</param>
+        void OnChanging(object instance, string propertyName, object oldValue, object newValue, string descriptionOfChange);
+
+        /// <summary>
+        /// Construct a Change instance with actions for undo / redo.
+        /// </summary>
+        /// <param name="instance">The instance that changed.</param>
+        /// <param name="propertyName">The property name that exposes the collection that changed. (Case sensitive, used by reflection.)</param>
+        /// <param name="collection">The collection that had an item added / removed.</param>
+        /// <param name="e">The NotifyCollectionChangedEventArgs event args parameter, with info about the collection change.</param>
+        void OnCollectionChanged(object instance, string propertyName, object collection, NotifyCollectionChangedEventArgs e);
+
+        /// <summary>
+        /// Construct a Change instance with actions for undo / redo.
+        /// </summary>
+        /// <param name="instance">The instance that changed.</param>
+        /// <param name="propertyName">The property name that exposes the collection that changed. (Case sensitive, used by reflection.)</param>
+        /// <param name="collection">The collection that had an item added / removed.</param>
+        /// <param name="e">The NotifyCollectionChangedEventArgs event args parameter, with info about the collection change.</param>
+        /// <param name="descriptionOfChange">A description of the change.</param>
+        void OnCollectionChanged(object instance, string propertyName, object collection, NotifyCollectionChangedEventArgs e, string descriptionOfChange);
+    }
+}

--- a/src/MonitoredUndo/IUndoService.cs
+++ b/src/MonitoredUndo/IUndoService.cs
@@ -1,0 +1,21 @@
+﻿namespace MonitoredUndo
+{
+    /// <summary>
+    /// A service representing the top level of the undo / redo system.
+    /// It contains one or more UndoRoots, accessible via an indexer.
+    /// </summary>
+    public interface IUndoService
+    {
+        /// <summary>
+        /// Get (or create) an UndoRoot for the specified object or document instance.
+        /// </summary>
+        /// <param name="root">The object that represents the root of the document or object hierarchy.</param>
+        /// <returns>An UndoRoot instance for this object.</returns>
+        UndoRoot this[object root] { get; }
+
+        /// <summary>
+        /// Clear the cached UndoRoots.
+        /// </summary>
+        void Clear();
+    }
+}

--- a/src/MonitoredUndo/UndoService.cs
+++ b/src/MonitoredUndo/UndoService.cs
@@ -7,9 +7,9 @@ using System.Collections;
 
 namespace MonitoredUndo
 {
-
-    public class UndoService
-    {        
+    /// <inheritdoc cref="IUndoService"/>
+    public class UndoService : IUndoService
+    {
 
         private static UndoService _Current;
         private static IDictionary<Type, WeakReference> _CurrentRootInstances;
@@ -88,7 +88,7 @@ namespace MonitoredUndo
             }
         }
 
-        
+
 
         // Use a weak reference for the key, to prevent memory leaks.
         private IDictionary<WeakReference, UndoRoot> _Roots;
@@ -99,15 +99,11 @@ namespace MonitoredUndo
             // Use a custom comparer to compare the WeakReference keys.
             _Roots = new Dictionary<WeakReference, UndoRoot>(new WeakReferenceComparer());
         }
-      
 
-        
 
-        /// <summary>
-        /// Get (or create) an UndoRoot for the specified object or document instance.
-        /// </summary>
-        /// <param name="root">The object that represents the root of the document or object hierarchy.</param>
-        /// <returns>An UndoRoot instance for this object.</returns>
+
+
+        /// <inheritdoc cref="IUndoService.this[object]"/>
         public UndoRoot this[object root]
         {
             get
@@ -129,11 +125,9 @@ namespace MonitoredUndo
 
                 return ret;
             }
-        }       
-        
-        /// <summary>
-        /// Clear the cached UndoRoots.
-        /// </summary>
+        }
+
+        /// <inheritdoc cref="IUndoService.Clear"/>
         public void Clear()
         {
             this._Roots.Clear();


### PR DESCRIPTION
Hi Nathan,

I was wanting to use Monitored Undo Framework in a [Prism](https://github.com/PrismLibrary/Prism) based project I’m working on, but Prism’s IoC functionality (like most others) seems to require services to have an interface abstraction for container registration and dependency injection.

To facilitate this, in this this pull request I’ve extracted interfaces from UndoService and ChangeFactory and moved XML documentation comments to the interfaces to avoid repetition.
These interfaces also make it easier to mock UndoService and ChangeFactory in unit tests.

With these changes I can register UndoService and ChangeFactory with the IoC container by adding the following lines to the overriden RegisterTypes method in my application’s App.xaml.cs:
```
containerRegistry.RegisterInstance<MonitoredUndo.IUndoService>(MonitoredUndo.UndoService.Current);
containerRegistry.RegisterSingleton<MonitoredUndo.IChangeFactory, MonitoredUndo.ChangeFactory>();
```

Thank you for your time and consideration.

Regards,

Daniel O’Connell