### PR TITLE
Added an internal ObservableStack collection implementing INotifyCollectionChanged for UndoRoot's Undo and Redo stacks

### DIFF
--- a/samples/WpfUndoSample/MainWindow.xaml.cs
+++ b/samples/WpfUndoSample/MainWindow.xaml.cs
@@ -42,24 +42,7 @@ namespace WpfUndoSample
 
         private void LayoutRoot_Loaded(object sender, RoutedEventArgs e)
         {
-            // The undo / redo stack collections are not "Observable", so we 
-            // need to manually refresh the UI when they change.
-            var root = UndoService.Current[this];
-            root.UndoStackChanged += new EventHandler(OnUndoStackChanged);
-            root.RedoStackChanged += new EventHandler(OnRedoStackChanged);
             FirstNameTextbox.Focus();
-        }
-
-        // Refresh the UI when the undo stack changes.
-        void OnUndoStackChanged(object sender, EventArgs e)
-        {
-            RefreshUndoStackList();
-        }
-
-        // Refresh the UI when the redo stack changes.
-        void OnRedoStackChanged(object sender, EventArgs e)
-        {
-            RefreshUndoStackList();
         }
 
 
@@ -245,18 +228,6 @@ namespace WpfUndoSample
         
 
         
-
-        // Refresh the UI when the undo / redo stacks change.
-        private void RefreshUndoStackList()
-        {
-            // Calling refresh on the CollectionView will tell the UI to rebind the list.
-            // If the list were an ObservableCollection, or implemented INotifyCollectionChanged, this would not be needed.
-            var cv = CollectionViewSource.GetDefaultView(UndoStack);
-            cv.Refresh();  
-
-            cv = CollectionViewSource.GetDefaultView(RedoStack);
-            cv.Refresh();
-        }
 
         
 

--- a/samples/WpfUndoSampleMVVM.Core/MainWindowViewModel.cs
+++ b/samples/WpfUndoSampleMVVM.Core/MainWindowViewModel.cs
@@ -82,25 +82,9 @@ namespace WpfUndoSampleMVVM.Core
 
         private void OnWindowLoaded()
         {
-            // The undo / redo stack collections are not "Observable", so we 
-            // need to manually refresh the UI when they change.
-            var root = UndoService.Current[this];
-            root.UndoStackChanged += new EventHandler(OnUndoStackChanged);
-            root.RedoStackChanged += new EventHandler(OnRedoStackChanged);
             //FirstNameTextbox.Focus();
         }
 
-        // Refresh the UI when the undo stack changes.
-        void OnUndoStackChanged(object sender, EventArgs e)
-        {
-            RefreshUndoStackList();
-        }
-
-        // Refresh the UI when the redo stack changes.
-        void OnRedoStackChanged(object sender, EventArgs e)
-        {
-            RefreshUndoStackList();
-        }
 
         
 
@@ -217,18 +201,6 @@ namespace WpfUndoSampleMVVM.Core
         
 
         
-
-        // Refresh the UI when the undo / redo stacks change.
-        private void RefreshUndoStackList()
-        {
-            // Calling refresh on the CollectionView will tell the UI to rebind the list.
-            // If the list were an ObservableCollection, or implemented INotifyCollectionChanged, this would not be needed.
-            var cv = CollectionViewSource.GetDefaultView(UndoStack);
-            cv.Refresh();
-
-            cv = CollectionViewSource.GetDefaultView(RedoStack);
-            cv.Refresh();
-        }
 
         
 

--- a/src/MonitoredUndo/ObservableStack.cs
+++ b/src/MonitoredUndo/ObservableStack.cs
@@ -1,0 +1,83 @@
+﻿/*
+    Based on sample code posted on Stack Overflow by 'Ernie S' (https://stackoverflow.com/users/1324284/ernie-s)
+    at https://stackoverflow.com/questions/3127136/observable-stack-and-queue/56177896#56177896
+*/
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+namespace MonitoredUndo
+{
+    /// <summary>
+    /// Observable version of the generic Stack collection
+    /// </summary>
+    internal class ObservableStack<T> : Stack<T>, INotifyCollectionChanged, INotifyPropertyChanged
+    {
+        #region Constructors
+
+        public ObservableStack() : base()
+        {
+        }
+
+        public ObservableStack(IEnumerable<T> collection) : base(collection)
+        {
+        }
+
+        public ObservableStack(int capacity) : base(capacity)
+        {
+        }
+
+        #endregion
+
+        #region Overrides
+
+        public new virtual T Pop()
+        {
+            T item = base.Pop();
+            OnCollectionChanged(NotifyCollectionChangedAction.Remove, item);
+
+            return item;
+        }
+
+        public new virtual void Push(T item)
+        {
+            base.Push(item);
+            OnCollectionChanged(NotifyCollectionChangedAction.Add, item);
+        }
+
+        public new virtual void Clear()
+        {
+            base.Clear();
+            OnCollectionChanged(NotifyCollectionChangedAction.Reset, default);
+        }
+
+        #endregion
+
+        #region CollectionChanged
+
+        public virtual event NotifyCollectionChangedEventHandler CollectionChanged;
+
+        protected virtual void OnCollectionChanged(NotifyCollectionChangedAction action, T item)
+        {
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(action,
+                item,
+                item == null ? -1 : 0)
+            );
+
+            OnPropertyChanged(nameof(Count));
+        }
+
+        #endregion
+
+        #region PropertyChanged
+
+        public virtual event PropertyChangedEventHandler PropertyChanged;
+
+        protected virtual void OnPropertyChanged(string proertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(proertyName));
+        }
+
+        #endregion
+    }
+}

--- a/src/MonitoredUndo/UndoRoot.cs
+++ b/src/MonitoredUndo/UndoRoot.cs
@@ -18,8 +18,8 @@ namespace MonitoredUndo
         private WeakReference _Root;
 
         // The list of undo / redo actions.
-        private Stack<ChangeSet> _UndoStack;
-        private Stack<ChangeSet> _RedoStack;
+        private ObservableStack<ChangeSet> _UndoStack;
+        private ObservableStack<ChangeSet> _RedoStack;
 
         // Tracks whether a batch (or batches) has been started.
         private int _IsInBatchCounter = 0;
@@ -53,8 +53,8 @@ namespace MonitoredUndo
         public UndoRoot(object root)
         {
             _Root = new WeakReference(root);
-            _UndoStack = new Stack<ChangeSet>();
-            _RedoStack = new Stack<ChangeSet>();
+            _UndoStack = new ObservableStack<ChangeSet>();
+            _RedoStack = new ObservableStack<ChangeSet>();
         }
 
         


### PR DESCRIPTION
Hi Nathan,

From the comments in the sample projects and my own experience binding UndoRoot’s UndoStack and RedoStack to ItemsSource properties in WPF, it would be a lot easier if these Stacks implemented INotifyCollectionChanged.

I found sample code for an ObservableStack collection [posted on Stack Overflow](https://stackoverflow.com/questions/3127136/observable-stack-and-queue/56177896#56177896) which seems to fit the bill and have added this class to the MonitoredUndo project with an attributation comment at the beginning of the file linking back to the post on Stack Overflow.

I replaced Stack collection instances with ObservableStack instances in UndoRoot and added unit test methods to confirm that UndoRoot.UndoStack and UndoRoot.RedoStack implement INotifyCollectionChanged and raise CollectionChanged events correctly.

Finally, I removed the unnecessary manual refresh of the undo / redo stack collections in the sample projects, since the 
Stacks now implement INotifyCollectionChanged.

Thank you for your time and consideration.

Regards,

Daniel O’Connell